### PR TITLE
Bug del Aside del carro solucionado - Exitoso.

### DIFF
--- a/js/script-carrito.js
+++ b/js/script-carrito.js
@@ -11,10 +11,11 @@ document.addEventListener('DOMContentLoaded', () => {
     let cart = [];
 
     // Abrir y cerrar el carrito
-    cartIcon.addEventListener('click', () => {
-        //cartAside.style.top = `${window.scrollY}px`;
+    cartIcon.addEventListener('click', (e) => {
+        e.preventDefault(); // Evita que el navegador haga scroll hacia arriba
         cartAside.classList.toggle('open');
     });
+
 
     closeCart.addEventListener('click', () => {
         cartAside.classList.remove('open');
@@ -88,4 +89,5 @@ document.addEventListener('DOMContentLoaded', () => {
         cart = [];
         updateCart();
     });
+    
 });


### PR DESCRIPTION
Antes ocurría que al añadir productos al carro y al abrir este, el propio hacia scroll al inicio de la pagina, por lo que con esta nueva actualización ya se mantiene la pagina independientemente desde donde se abra el aside del carro. 😄 